### PR TITLE
feat(SECURITY-9): Bump up to folio-spring-base-7.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
   <properties>
     <java.version>17</java.version>
     <edge-common-spring-version>2.3.0</edge-common-spring-version>
+    <folio-spring-support-version>7.2.1</folio-spring-support-version>
+    <edge-api-utils-version>1.3.0</edge-api-utils-version>
     <openapi-generator.version>6.5.0</openapi-generator.version>
     <spring-cloud-wiremock>4.0.2</spring-cloud-wiremock>
     <swagger-parser.version>2.1.14</swagger-parser.version>
@@ -36,7 +38,32 @@
     <dependency>
        <groupId>org.folio</groupId>
        <artifactId>folio-spring-cql</artifactId>
-       <version>7.1.2</version>
+       <version>${folio-spring-support-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-base</artifactId>
+      <version>${folio-spring-support-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-system-user</artifactId>
+      <version>${folio-spring-support-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>edge-api-utils</artifactId>
+      <version>${edge-api-utils-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ header.validation.x-okapi-tenant.exclude.base-paths: /admin,/swagger,/v2/api-doc
 folio:
   system-user:
     username: dummy # This isn't actually used, but we get dependency injection errors from folio-spring-system-user if we don't have it
+    password: dummy
   environment: dev # Overridden at runtime in production, but causes folio-spring-system-user DI errors if it's not set
   tenant:
     validation:


### PR DESCRIPTION
https://issues.folio.org/browse/SECURITY-9

Bump up the version of folio-spring-base for edge-courses according to security changes related to setup of system users 