### PR TITLE
EDGCOURSES-7 EDGCOURSES-8 Upgrade edge-common-spring version and add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,96 @@ Three secure stores currently implemented for safe retrieval of encrypted creden
 
 Only intended for _development purposes_.  Credentials are defined in plain text in a specified properties file.  See `src/main/resources/ephemeral.properties`
 
+### TLS Configuration for HTTP Endpoints
+
+To configure Transport Layer Security (TLS) for HTTP endpoints in edge module, the following configuration parameters can be used. These parameters allow you to specify key and keystore details necessary for setting up TLS.
+
+#### Configuration Parameters
+
+1. **`spring.ssl.bundle.jks.web-server.key.password`**
+- **Description**: Specifies the password for the private key in the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.password=SecretPassword`
+
+2. **`spring.ssl.bundle.jks.web-server.key.alias`**
+- **Description**: Specifies the alias of the key within the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.alias=localhost`
+
+3. **`spring.ssl.bundle.jks.web-server.keystore.location`**
+- **Description**: Specifies the location of the keystore file in the local file system.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.location=/some/secure/path/test.keystore.bcfks`
+
+4. **`spring.ssl.bundle.jks.web-server.keystore.password`**
+- **Description**: Specifies the password for the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword`
+
+5. **`spring.ssl.bundle.jks.web-server.keystore.type`**
+- **Description**: Specifies the type of the keystore. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.type=BCFKS`
+
+6. **`server.ssl.bundle`**
+- **Description**: Specifies which SSL bundle to use for configuring the server. This parameter links to the defined SSL bundle, for example, `web-server`.
+- **Example**: `server.ssl.bundle=web-server`
+
+7. **`server.port`**
+- **Description**: Specifies the port on which the server will listen for HTTPS requests.
+- **Example**: `server.port=8443`
+
+#### Example Configuration
+
+To enable TLS for the edge module using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+spring.ssl.bundle.jks.web-server.key.password=SecretPassword
+spring.ssl.bundle.jks.web-server.key.alias=localhost
+spring.ssl.bundle.jks.web-server.keystore.location=classpath:test/test.keystore.bcfks
+spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword
+spring.ssl.bundle.jks.web-server.keystore.type=BCFKS
+
+server.ssl.bundle=web-server
+server.port=8443
+```
+### TLS Configuration for Feign HTTP Clients
+
+To configure Transport Layer Security (TLS) for HTTP clients created using Feign annotations in the edge module, you can use the following configuration parameters. These parameters allow you to specify trust store details necessary for setting up TLS for Feign clients.
+
+#### Configuration Parameters
+
+1. **`folio.client.okapiUrl`**
+- **Description**: Specifies the base URL for the Okapi service.
+- **Example**: `folio.client.okapiUrl=https://okapi:443`
+
+2. **`folio.client.tls.enabled`**
+- **Description**: Enables or disables TLS for the Feign clients.
+- **Example**: `folio.client.tls.enabled=true`
+
+3. **`folio.client.tls.trustStorePath`**
+- **Description**: Specifies the location of the trust store file.
+- **Example**: `folio.client.tls.trustStorePath=classpath:/some/secure/path/test.truststore.bcfks`
+
+4. **`folio.client.tls.trustStorePassword`**
+- **Description**: Specifies the password for the trust store.
+- **Example**: `folio.client.tls.trustStorePassword="SecretPassword"`
+
+5. **`folio.client.tls.trustStoreType`**
+- **Description**: Specifies the type of the trust store. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `folio.client.tls.trustStoreType=bcfks`
+
+#### Note
+The `trustStorePath`, `trustStorePassword`, and `trustStoreType` parameters can be omitted if the server provides a public certificate.
+
+#### Example Configuration
+
+To enable TLS for Feign HTTP clients using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+folio.client.okapiUrl=https://okapi:443
+folio.client.tls.enabled=true
+folio.client.tls.trustStorePath=classpath:test/test.truststore.bcfks
+folio.client.tls.trustStorePassword=SecretPassword
+folio.client.tls.trustStoreType=bcfks
+```
+
+
 ## Additional Information
 ### Issue tracker
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ spring.ssl.bundle.jks.web-server.keystore.type=BCFKS
 server.ssl.bundle=web-server
 server.port=8443
 ```
+Also, you can use the relaxed binding with the upper case format, which is recommended when using system environment variables.
+```properties
+SPRING_SSL_BUNDLE_JKS_WEB-SERVER_KEY_PASSWORD=SecretPassword
+SPRING_SSL_BUNDLE_JKS_WEB-SERVER_KEY_ALIAS=localhost
+SPRING_SSL_BUNDLE_JKS_WEB-SERVER_KEYSTORE_LOCATION=classpath:test/test.keystore.bcfks
+SPRING_SSL_BUNDLE_JKS_WEB-SERVER_KEYSTORE_PASSWORD=SecretPassword
+SPRING_SSL_BUNDLE_JKS_WEB-SERVER_KEYSTORE_TYPE=BCFKS
+
+SERVER_SSL_BUNDLE=web-server
+SERVER_PORT=8443
+```
+
 ### TLS Configuration for Feign HTTP Clients
 
 To configure Transport Layer Security (TLS) for HTTP clients created using Feign annotations in the edge module, you can use the following configuration parameters. These parameters allow you to specify trust store details necessary for setting up TLS for Feign clients.
@@ -128,7 +140,14 @@ folio.client.tls.trustStorePath=classpath:test/test.truststore.bcfks
 folio.client.tls.trustStorePassword=SecretPassword
 folio.client.tls.trustStoreType=bcfks
 ```
-
+Also, you can use the relaxed binding with the upper case format, which is recommended when using system environment variables.
+```properties
+FOLIO_CLIENT_OKAPIURL=https://okapi:443
+FOLIO_CLIENT_TLS_ENABLED=true
+FOLIO_CLIENT_TLS_TRUSTSTOREPATH=classpath:test/test.truststore.bcfks
+FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD=SecretPassword
+FOLIO_CLIENT_TLS_TRUSTSTORETYPE=bcfks
+```
 
 ## Additional Information
 ### Issue tracker

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring-version>2.4.2</edge-common-spring-version>
+    <edge-common-spring-version>2.4.3</edge-common-spring-version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <spring-cloud-wiremock>4.1.1</spring-cloud-wiremock>
     <swagger-parser.version>2.1.20</swagger-parser.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring-version>2.4.1</edge-common-spring-version>
+    <edge-common-spring-version>2.4.2</edge-common-spring-version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <spring-cloud-wiremock>4.1.1</spring-cloud-wiremock>
     <swagger-parser.version>2.1.20</swagger-parser.version>
@@ -34,13 +34,32 @@
     <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>
     <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
     <jknack.handlebars.version>4.4.0</jknack.handlebars.version>
+    <bc-fips.version>1.0.2.5</bc-fips.version>
+    <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
+    <bctls-fips.version>1.0.19</bctls-fips.version>
+    <folio-spring-cql.version>7.1.2</folio-spring-cql.version>
   </properties>
 
   <dependencies>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bc-fips</artifactId>
+      <version>${bc-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-fips</artifactId>
+      <version>${bcpkix-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-fips</artifactId>
+      <version>${bctls-fips.version}</version>
+    </dependency>
+    <dependency>
        <groupId>org.folio</groupId>
        <artifactId>folio-spring-cql</artifactId>
-       <version>7.1.2</version>
+       <version>${folio-spring-cql.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -87,6 +106,10 @@
         <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/org/folio/edge/courses/EdgeCoursesApplication.java
+++ b/src/main/java/org/folio/edge/courses/EdgeCoursesApplication.java
@@ -1,16 +1,20 @@
 package org.folio.edge.courses;
 
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.folio.spring.cql.JpaCqlConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
+import java.security.Security;
+
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, JpaCqlConfiguration.class})
 @EnableFeignClients
 public class EdgeCoursesApplication {
 
   public static void main(String[] args) {
+    Security.addProvider(new BouncyCastleFipsProvider());
     SpringApplication.run(EdgeCoursesApplication.class, args);
   }
 

--- a/src/main/java/org/folio/edge/courses/config/CourseClientConfig.java
+++ b/src/main/java/org/folio/edge/courses/config/CourseClientConfig.java
@@ -2,11 +2,43 @@ package org.folio.edge.courses.config;
 
 import feign.RequestInterceptor;
 import feign.okhttp.OkHttpClient;
+import lombok.AllArgsConstructor;
+import okhttp3.ConnectionPool;
+import okhttp3.Protocol;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.edgecommonspring.security.SecurityManagerService;
 import org.folio.spring.FolioExecutionContext;
+import org.springframework.cloud.openfeign.support.FeignHttpClientProperties;
 import org.springframework.context.annotation.Bean;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.folio.common.utils.FeignClientTlsUtils.getSslOkHttpClient;
+
+@AllArgsConstructor
 public class CourseClientConfig {
+  private final EdgeFeignClientProperties properties;
+
+  @Bean
+  public okhttp3.OkHttpClient okHttpClient(okhttp3.OkHttpClient.Builder builder, ConnectionPool connectionPool,
+                                           FeignHttpClientProperties httpClientProperties) {
+    boolean followRedirects = httpClientProperties.isFollowRedirects();
+    int connectTimeout = httpClientProperties.getConnectionTimeout();
+    Duration readTimeout = httpClientProperties.getOkHttp().getReadTimeout();
+    List<Protocol> protocols = httpClientProperties.getOkHttp().getProtocols().stream().map(Protocol::valueOf)
+            .collect(Collectors.toList());
+
+    builder.connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+            .followRedirects(followRedirects).readTimeout(readTimeout).connectionPool(connectionPool)
+            .protocols(protocols).build();
+    var tls = properties.getTls();
+    return tls != null  && Boolean.TRUE.equals(tls.isEnabled()) ?
+            getSslOkHttpClient(builder.build(), tls) : builder.build();
+  }
+
 
   @Bean
   public OkHttpClient feignOkHttpClient(okhttp3.OkHttpClient okHttpClient) {
@@ -16,6 +48,6 @@ public class CourseClientConfig {
   @Bean
   public RequestInterceptor courseClientRequestInterceptor(FolioExecutionContext context,
     SecurityManagerService securityManagerService) {
-    return new CourseClientRequestInterceptor(context, securityManagerService);
+    return new CourseClientRequestInterceptor(properties, context, securityManagerService);
   }
 }

--- a/src/main/java/org/folio/edge/courses/service/CourseReservesService.java
+++ b/src/main/java/org/folio/edge/courses/service/CourseReservesService.java
@@ -34,9 +34,6 @@ public class CourseReservesService {
   private final CourseClient courseClient;
   private final JsonConverter jsonConverter;
 
-  @Value("${okapi_url}")
-  private String okapiUrl;
-
   public String getCoursesByQuery(RequestQueryParameters requestQueryParameters) {
     log.info("Calling getCoursesByQuery with query: {}", requestQueryParameters.getQuery());
     var courses = courseClient.getCourseByQuery(requestQueryParameters);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,13 @@ folio:
   tenant:
     validation:
       enabled: false
-
+  client:
+    okapiUrl: http://localhost:9130
+    tls:
+      enabled: false
+#      trustStorePath: ~/test/test.truststore.bcfks
+#      trustStorePassword: "SecretPassword"
+#      trustStoreType: BCFKS
 logging:
   config: classpath:log4j2.xml
 

--- a/src/test/java/org/folio/edge/courses/BaseIntegrationTests.java
+++ b/src/test/java/org/folio/edge/courses/BaseIntegrationTests.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.folio.edge.courses.config.CourseClientRequestInterceptor;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.edgecommonspring.client.EnrichUrlClient;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.AfterAll;
@@ -44,10 +45,12 @@ public abstract class BaseIntegrationTests {
 
   @BeforeAll
   static void beforeAll(@Autowired EnrichUrlClient enrichUrlClient,
-    @Autowired CourseClientRequestInterceptor interceptor) {
+    @Autowired CourseClientRequestInterceptor interceptor, @Autowired EdgeFeignClientProperties properties) {
     WIRE_MOCK.start();
-    ReflectionTestUtils.setField(enrichUrlClient, OKAPI_URL, WIRE_MOCK.baseUrl());
-    ReflectionTestUtils.setField(interceptor, OKAPI_URL, WIRE_MOCK.baseUrl());
+    var url = WIRE_MOCK.baseUrl();
+    ReflectionTestUtils.setField(enrichUrlClient, OKAPI_URL, url);
+    ReflectionTestUtils.setField(interceptor, OKAPI_URL, url);
+    ReflectionTestUtils.setField(properties, OKAPI_URL, url);
   }
 
   @AfterAll

--- a/src/test/java/org/folio/edge/courses/config/CourseClientRequestInterceptorTest.java
+++ b/src/test/java/org/folio/edge/courses/config/CourseClientRequestInterceptorTest.java
@@ -14,7 +14,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+
 import org.folio.edge.api.utils.exception.AuthorizationException;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.edgecommonspring.domain.entity.ConnectionSystemParameters;
 import org.folio.edgecommonspring.security.SecurityManagerService;
 import org.folio.spring.FolioExecutionContext;
@@ -46,6 +48,8 @@ class CourseClientRequestInterceptorTest {
   private ConnectionSystemParameters connectionSystemParameters;
   @Mock
   private HttpServletRequest servletRequest;
+  @Mock
+  private EdgeFeignClientProperties properties;
 
 
   @BeforeEach

--- a/src/test/java/org/folio/edge/courses/controller/CourseReservesControllerIT.java
+++ b/src/test/java/org/folio/edge/courses/controller/CourseReservesControllerIT.java
@@ -50,12 +50,6 @@ class CourseReservesControllerIT extends BaseIntegrationTests {
   @Autowired
   private CourseReservesService courseReservesService;
 
-  @BeforeEach
-  void before() {
-    ReflectionTestUtils
-      .setField(courseReservesService, "okapiUrl", WIRE_MOCK.baseUrl());
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {COURSES_URL_WITH_QUERY, RESERVES_URL_BY_ID, DEPARTMENTS_URL, INSTRUCTORS_URL})
   void getCoursesAndReserves_shouldReturnBadRequest_whenLangParamInvalid(String endpoint)

--- a/src/test/java/org/folio/edge/courses/handler/CoursesErrorHandlerTest.java
+++ b/src/test/java/org/folio/edge/courses/handler/CoursesErrorHandlerTest.java
@@ -24,11 +24,6 @@ class CoursesErrorHandlerTest extends BaseIntegrationTests {
   @Autowired
   private CourseReservesService courseReservesService;
 
-  @BeforeEach
-  void before() {
-    ReflectionTestUtils.setField(courseReservesService, "okapiUrl", BaseIntegrationTests.WIRE_MOCK.baseUrl());
-  }
-
   @Test
   void handleForbiddenException_shouldProcessException() throws Exception {
     doGet(mockMvc, COURSE_BY_ID_FORBIDDEN_URI)


### PR DESCRIPTION
Upgraded dependency on the edge-common version to 2.4.2. 
Added support for TLS in HTTP endpoints and Feign HTTP Clients. Implemented BouncyCastleFipsProvider to be used as a security provider if configured. Included instructions for configuring TLS in the README file.