### PR TITLE
Replace BouncyCastleFipsProvider with Folio-tls-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,23 +38,14 @@
     <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
     <bctls-fips.version>1.0.19</bctls-fips.version>
     <folio-spring-cql.version>7.1.2</folio-spring-cql.version>
+    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bc-fips</artifactId>
-      <version>${bc-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-fips</artifactId>
-      <version>${bcpkix-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-fips</artifactId>
-      <version>${bctls-fips.version}</version>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${folio-tls-utils.version}</version>
     </dependency>
     <dependency>
        <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/edge/courses/EdgeCoursesApplication.java
+++ b/src/main/java/org/folio/edge/courses/EdgeCoursesApplication.java
@@ -1,20 +1,21 @@
 package org.folio.edge.courses;
 
-import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import lombok.extern.log4j.Log4j2;
 import org.folio.spring.cql.JpaCqlConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-import java.security.Security;
+import static org.folio.common.utils.tls.FipsChecker.getFipsChecksResultString;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, JpaCqlConfiguration.class})
 @EnableFeignClients
+@Log4j2
 public class EdgeCoursesApplication {
 
   public static void main(String[] args) {
-    Security.addProvider(new BouncyCastleFipsProvider());
+    log.info(getFipsChecksResultString());
     SpringApplication.run(EdgeCoursesApplication.class, args);
   }
 


### PR DESCRIPTION
The BouncyCastleFipsProvider library has been removed and replaced by the Folio-tls-utils library in the EdgeCoursesApplication class and pom.xml file. The commits also include logging the FIPS checks results into the application's main method.