### PR TITLE
bump up edge-common-spring to v2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring-version>2.4.4</edge-common-spring-version>
+    <edge-common-spring-version>2.4.5</edge-common-spring-version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <spring-cloud-wiremock>4.1.1</spring-cloud-wiremock>
     <swagger-parser.version>2.1.20</swagger-parser.version>


### PR DESCRIPTION
Bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules