### PR TITLE
EDGCOURSES-15: Spring Boot 3.3.6 fixing security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.6</version>
+    <version>3.3.6</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCOURSES-15

Upgrade Spring Boot from 3.2.6 to 3.3.6 fixing these security vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-38286 tomcat-embed-core Allocation of Resources Without Limits or Throttling
* https://www.cve.org/CVERecord?id=CVE-2024-34750 tomcat-embed-core Insufficient Session Expiration
* https://www.cve.org/CVERecord?id=CVE-2024-38809 spring-web Denial of Service (DoS)
* https://www.cve.org/CVERecord?id=CVE-2024-38827 spring-security-crypto Authorization Bypass
* https://nvd.nist.gov/vuln/detail/CVE-2024-38820 spring-* Improper Handling of Case Sensitivity