### PR TITLE
FOLIO-4553: Set "permissions: contents: read" in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,9 +1,14 @@
+# https://github.com/folio-org/.github/blob/master/README-maven.md
+
 name: Maven central workflow
 
 on:
   push:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   maven:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## WIP
+
+[FOLIO-4553](https://folio-org.atlassian.net/browse/FOLIO-4553) Set "permissions: contents: read" in maven.yml
+
 ## v1.7.0  2026-04-16
 
 [EDGCOURSES-21](https://folio-org.atlassian.net/browse/EDGCOURSES-21) Fix invalid YAML api


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4553

## Purpose

Adding "permissions: contents: read" to the repository’s maven.yml file that calls the central maven github action workflow is best practice and significantly reduces supply chain attacks: https://docs.github.com/en/actions/reference/security/secure-use

## Approach

Add "permissions: contents: read" in maven.yml

## Changes Checklist
- n/a **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- n/a **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- n/a **Interface Version Changes**: Indicate any changes to interface versions.
- n/a **Interface Dependencies**: Document added or removed dependencies.
- n/a **Permissions**: Document any changes to permissions.
- n/a **Logging**: Confirm that logging is appropriately handled.
- n/a **Unit Testing**: Confirm that changed classes were covered by unit tests.
- n/a **Integration Testing**: Confirm that changed logic was covered by integration tests.
- n/a **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

## Learning and Resources (if applicable)

Don´t copy outdated maven.yml from other repositories but from the official documentation: https://github.com/folio-org/.github/blob/master/README-maven.md#usage